### PR TITLE
Downgrade Log4j SLF4J bridge to match Minecraft's log4j version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,8 +111,8 @@ dependencies {
 	include "fr.catcore:server-translations-api:1.4.1"
 
 	include "org.slf4j:slf4j-api:1.7.25"
-	implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.13.1"
-	include "org.apache.logging.log4j:log4j-slf4j-impl:2.13.1"
+	implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.8.1"
+	include "org.apache.logging.log4j:log4j-slf4j-impl:2.8.1"
 }
 
 processResources {


### PR DESCRIPTION
Minecraft uses an outdated Log4j version (2.8.1), so you have to too.
This causes a crash otherwise:
```
[13:28:52] [Server thread/ERROR]: Encountered an unexpected exception                                                                                         java.lang.NoClassDefFoundError: org/apache/logging/log4j/util/StackLocatorUtil
        at Not Enough Crashes deobfuscated stack trace.(1.16.4+build.7) ~[?:?]
        at org.apache.logging.slf4j.Log4jLoggerFactory.getContext(Log4jLoggerFactory.java:44) ~[5b38d809-38a3-48fe-b333-8c2a7947db01.jar:?]
        at org.apache.logging.log4j.spi.AbstractLoggerAdapter.getLogger(AbstractLoggerAdapter.java:46) ~[server.jar:?]
        at org.apache.logging.slf4j.Log4jLoggerFactory.getLogger(Log4jLoggerFactory.java:30) ~[5b38d809-38a3-48fe-b333-8c2a7947db01.jar:?]
        at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:358) ~[5a2cd542-965a-41fd-bce9-abca8d0c96b0.jar:?]
        at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:383) ~[5a2cd542-965a-41fd-bce9-abca8d0c96b0.jar:?]
        at me.geek.tom.serverutils.libs.net.dv8tion.jda.internal.utils.JDALogger.getLog(JDALogger.java:119) ~[TomsServerTools-v0.2.3.jar:?]
        at me.geek.tom.serverutils.libs.net.dv8tion.jda.internal.utils.IOUtil.<clinit>(IOUtil.java:35) ~[TomsServerTools-v0.2.3.jar:?]
        at me.geek.tom.serverutils.libs.net.dv8tion.jda.api.JDABuilder.build(JDABuilder.java:1877) ~[TomsServerTools-v0.2.3.jar:?]
        at me.geek.tom.serverutils.bot.impl.DiscordBotConnection.connect(DiscordBotConnection.java:49) ~[TomsServerTools-v0.2.3.jar:?]
        at me.geek.tom.serverutils.TomsServerUtils.starting(TomsServerUtils.java:108) ~[TomsServerTools-v0.2.3.jar:?]
        at net.minecraft.server.MinecraftServer.handler$zjj000$serverutils_serverStarting(MinecraftServer:3701) ~[intermediary-server.jar:?]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer:645) ~[intermediary-server.jar:?]
        at net.minecraft.server.MinecraftServer.method_29739(MinecraftServer:257) ~[intermediary-server.jar:?]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_282]
```﻿
