### PR TITLE
Seperate chat and events to different webhooks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ yarn_mappings               = 1.16.4+build.7
 loader_version              = 0.10.8
 
 #Mod properties
-mod_version                 = 0.1.2
+mod_version                 = 0.1.3
 maven_group                 = me.geek.tom
 archives_base_name          = TomsServerTools
 

--- a/src/main/kotlin/Config.kt
+++ b/src/main/kotlin/Config.kt
@@ -10,7 +10,8 @@ import java.nio.file.Path
 
 object DiscordBotSpec : ConfigSpec() {
     val token by required<String>()
-    val webhook by required<String>()
+    val chatWebhook by required<String>()
+    val eventWebhook by required<String>()
     val messageChannel by required<String>()
     val serverIcon by required<String>()
 
@@ -42,6 +43,7 @@ object HomesSpec : ConfigSpec() {
     val allowCrossDimension by required<Boolean>()
     val maxHomeAmount by required<Int>()
     val maxHomesPerDimension by required<Boolean>()
+    val homeDelay by required<Int>()
 }
 
 fun loadConfig(configDir: Path): Config {

--- a/src/main/kotlin/Config.kt
+++ b/src/main/kotlin/Config.kt
@@ -43,7 +43,6 @@ object HomesSpec : ConfigSpec() {
     val allowCrossDimension by required<Boolean>()
     val maxHomeAmount by required<Int>()
     val maxHomesPerDimension by required<Boolean>()
-    val homeDelay by required<Int>()
 }
 
 fun loadConfig(configDir: Path): Config {

--- a/src/main/resources/serverutils_default.toml
+++ b/src/main/resources/serverutils_default.toml
@@ -11,7 +11,9 @@
     # Create a app at https://discord.com/developers/applications, add a bot and then copy the token here
     token = ""
     # The Discord webhook URL to send the Minecraft chat to
-    webhook = ""
+    chat_webhook = ""
+    # The Discord webhook URL to send Minecraft events (such as joins and leaves) to
+    event_webhook = ""
     # The ID of the channel to listen for messages to send to Minecraft.
     message_channel = ""
 


### PR DESCRIPTION
This just seperates chat messages and events (things like deaths, players joining and leaving, server starting up, etc) to seperate webhook configs. I implemented this because we've got spleef on my server, and the deaths would constantly spam the channel, so people would mute the channel and reading the logs for actual messages was quite tedious.